### PR TITLE
Pull 40px^2 gravatar instead of resiszing an 80px^2 one

### DIFF
--- a/views/repo.erb
+++ b/views/repo.erb
@@ -16,7 +16,7 @@
 </ul>
 
 <div class="clear"></div>
-<div id="title"> <h1> Commits: <% count = 0; contributors.each {|u| count += u["contributions"]}%> <%=count%> / 
+<div id="title"> <h1> Commits: <% count = 0; contributors.each {|u| count += u["contributions"]}%> <%=count%> /
     Committers: <%= contributors.length %></h1></div>
 
 <table align="center">
@@ -36,7 +36,7 @@
       <tr>
         <td>
           <a href="https://github.com/<%=h e["login"]%>/">
-            <img src="http://www.gravatar.com/avatar.php?gravatar_id=<%=h e["gravatar_id"] %>" width="40" height="40" />
+            <img src="http://www.gravatar.com/avatar.php?gravatar_id=<%=h e["gravatar_id"] %>?s=40" width="40" height="40" />
           </a>
         </td>
 


### PR DESCRIPTION
I noticed that you were resizing gravatar images; this will speed things up _a little_ :metal:

> By default, images are presented at 80px by 80px if no size parameter is supplied. You may request a specific image size, which will be dynamically delivered from Gravatar by using the s= or size= parameter and passing a single pixel dimension (since the images are square):
> 
> http://www.gravatar.com/avatar/205e460b479e2e5b48aec07710c08d50?s=200
